### PR TITLE
Added reactivity for defaultSearchOptions property as computed prop.

### DIFF
--- a/src/Multiselect.vue
+++ b/src/Multiselect.vue
@@ -1,226 +1,330 @@
 <template>
-    <div>
-        <div :tabindex="disabled ? null : 0" :class="className" @keydown="handleKeyDown">
-            <div v-if="showInput">
-                <component is="selectedOptions"></component>
-                <div class="d-flex flex-row" :class="{'mt-2': countSelectedOptions}">
-                    <component is="searchOrStub" ref="input"></component>
-                    <component is="caretAndSpin"></component>
-                </div>
-            </div>
-            <div class="d-flex flex-row" v-else>
-                <component is="searchOrStub" ref="input" v-if="showSearchOrStub"></component>
-                <component is="selectedOptions" class="w-100"></component>
-                <component is="caretAndSpin"></component>
-            </div>
-        </div>
-        <div v-show="isShowDropdownList" ref="dropdownList" class="mt-1 dropdown-list" :style="{width: dropdownWidth}">
-            <ul class="list-group">
-                <li v-for="(option, index) in dropdownOptions"
-                    @click="handleSelectDropdownOption($event, option)"
-                    @mouseover="dropdownHoverIndex = index"
-                    class="list-group-item py-1 px-3"
-                    :class="{'bg-light': dropdownHoverIndex === index}"
-                >
-                    <img v-if="getOptionImage(option)" class="mr-2"
-                         :src="getOptionImage(option)"
-                         :alt="getOptionTitle(option)"
-                    />
-                    <span v-if="showDropdownHighlightTitle" v-html="getOptionHighlightTitle(option)"></span>
-                    <span v-else>{{ getOptionTitle(option) }}</span>
-                </li>
-                <li v-if="showDropdownNoResults" class="list-group-item text-muted py-2 px-3">
-                    {{ getProp('noResultsText') }}
-                </li>
-            </ul>
-        </div>
+    <div class="form-control p-0 multiselect"
+         tabindex="1"
+         @keydown="handleKeyDown"
+    >
+        <component is="tags"
+                   :short="shortTags"
+                   :options="options"
+                   :title-name="optionTitleName"
+                   :image-name="optionImageName"
+                   :key-name="optionKeyName"
+                   :on-drop="handleDropOption"
+                   :dropdown-list-count="Object.keys(dropdownOptions).length"
+                   :is-show-dropdown-list="showDropdownList"
+                   :on-show-dropdown-list="handleShowDropdownList"
+                   :on-hide-dropdown-list="handleHideDropdownList"
+                   :is-show-search="showSearch"
+        ></component>
+        <component is="search"
+                   :is-show-dropdown-list="showDropdownList"
+                   :dropdown-list-count="Object.keys(dropdownOptions).length"
+                   :on-show-dropdown-list="handleShowDropdownList"
+                   :on-hide-dropdown-list="handleHideDropdownList"
+                   :placeholder="placeholder"
+                   :on-search="handleSearch"
+                   :is-show="showSearch"
+                   :options-count="options.length"
+        ></component>
+        <component is="stub"
+                   :is-show-dropdown-list="showDropdownList"
+                   :dropdown-list-count="Object.keys(dropdownOptions).length"
+                   :on-show-dropdown-list="handleShowDropdownList"
+                   :on-hide-dropdown-list="handleHideDropdownList"
+                   :placeholder="stubPlaceholder"
+                   :is-show="showStub"
+                   :options-count="options.length"
+        ></component>
+        <component is="list"
+                   :show="showDropdownList"
+                   :options="dropdownOptions"
+                   :on-select="handleSelectFromDropdownList"
+                   :on-hide="handleHideDropdownList"
+                   :title-name="optionTitleName"
+                   :image-name="optionImageName"
+                   :key-name="optionKeyName"
+        ></component>
+        <input type="hidden" :name="name + (isMulti ? '[]' : '')" v-for="option in options" v-if="attachInput"
+               :value="option.id"/>
     </div>
 </template>
 
 <script>
-  import selectedOptions from './components/selectedOptions.vue'
-  import caretAndSpin from './components/caretAndSpin.vue'
-  import searchOrStub from './components/searchOrStub.vue'
-  import mixin from './mixins/MultiselectMixin'
+  import tags from './components/Tags.vue'
+  import search from './components/Search.vue'
+  import list from './components/List.vue'
+  import stub from './components/Stub.vue'
+  import axios from 'axios'
 
   export default {
-    components: {selectedOptions, caretAndSpin, searchOrStub},
-    mixins: [mixin],
-    name: 'vue-bootstrap-multiselect',
+    components: {tags, search, list, stub},
     props: {
-      // Default options
-      'default': {
-        type: [Array, Object],
-        'default': function () {
+      shortTags: {type: Boolean},
+      placeholder: {type: String},
+      stubPlaceholder: {type: String},
+      optionTitleName: {type: String, default: 'title'},
+      optionImageName: {type: String, default: 'image'},
+      optionKeyName: {type: String, default: 'id'},
+      asyncSearchCallback: {type: Function, default: null},
+      asyncSearchUrl: {type: String, default: null},
+      name: {type: String, default: null},
+      attachInput: {type: Boolean, default: false},
+      isMulti: {type: Boolean, default: false},
+      isSearch: {type: Boolean, default: true},
+      noResultsPlaceholder: {type: String, default: 'No results'},
+      value: {
+        type: [Array, Object, String],
+        default: function () {
           return []
         }
       },
-      // attach input type hidden for send forms
-      attachInput: {
-        type: Boolean,
-        'default': null
-      },
-      name: {
-        type: String,
-        'default': null
-      },
-      isMulti: {
-        type: Boolean,
-        'default': null
-      },
-      optionKeyName: {
-        type: String,
-        'default': null
-      },
-      optionTitleName: {
-        type: String,
-        'default': null
-      },
-      optionImageName: {
-        type: String,
-        'default': null
-      },
-      asyncSearchCallback: {
-        type: Function,
-        'default': null
-      },
-      asyncSearchUrl: {
-        type: String,
-        'default': null
-      },
-      placeholder: {
-        type: String,
-        'default': null
-      },
-      noResultsText: {
-        type: String,
-        'default': null
-      },
-      value: {
-        type: [String, Object, Array, null],
-        'default': null
-      },
       allValues: {
-        type: Array,
-        'default': null
+        type: [Array, Object],
+        default: function () {
+          return []
+        }
       },
-      hasSearch: {
-        type: Boolean,
-        'default': null
-      },
-      stubText: {
-        type: String,
-        'default': null
-      },
-      disabled: {
-        type: Boolean,
-        'default': false
-      },
-      hasHighlights: {
-        type: Boolean,
-        'default': null
-      },
-      id: {
-        type: String,
-        'default': null
+      onChange: {
+        type: Function,
+        default: null
+      }
+    },
+    data () {
+      return {
+        showDropdownList: false,
+        selectedOptions: [],
+        searchOptions: null,
       }
     },
     computed: {
-      className () {
-        return {
-          'form-control multiselect py-1 pr-1': true,
-          'disabled': this.disabled
+      options () {
+        return this.selectedOptions
+      },
+      dropdownOptions () {
+        let results = []
+        let options = this.searchOptions instanceof Object ? this.searchOptions : this.defaultSearchOptions
+        let selected = this.options
+        for (let index = 0; index < options.length; index++) {
+          let isSearch = false
+          for (let selectedIndex = 0; selectedIndex < selected.length; selectedIndex++) {
+            if (selected[selectedIndex][this.optionKeyName] === options[index][this.optionKeyName]) {
+              isSearch = true
+            }
+          }
+
+          if (!isSearch) {
+            results.push(options[index])
+          }
+        }
+
+        return results
+      },
+      showSearch () {
+        return !!(this.isSearch && (this.isMulti || !Object.keys(this.options).length))
+      },
+      showStub () {
+        return !!((!this.isSearch || (!this.isMulti && Object.keys(this.options).length)) && !this.options.length)
+      },
+      defaultSearchOptions: function(){
+        return this.convertOptionsToObjects(this.allValues)
+      }
+    },
+    methods: {
+      handleShowDropdownList () {
+        this.showDropdownList = true
+      },
+      handleHideDropdownList () {
+        this.showDropdownList = false
+      },
+      handleSelectFromDropdownList (option) {
+        if (this.isMulti) {
+          let results = Object.assign([], this.selectedOptions)
+          results.push(option)
+          this.selectedOptions = results
+        } else {
+          this.selectedOptions = [option]
+        }
+
+        if (!this.dropdownOptions.length || !this.isMulti) {
+          this.handleHideDropdownList()
+        }
+
+        if (this.onChange instanceof Function) {
+          this.onChange(this.selectedOptions)
         }
       },
-      showSearchOrStub () {
-        return !this.countSelectedOptions || this.getProp('hasSearch')
+      handleDropOption (option) {
+        let result = []
+        for (let index = 0; index < this.selectedOptions.length; index++) {
+          if (this.selectedOptions[index] !== option) {
+            result.push(this.selectedOptions[index])
+          }
+        }
+
+        this.selectedOptions = result
+
+        // Добавляем удаленный элемент в список найденных
+        if (this.searchOptions instanceof Object && this.searchOptions.indexOf(option) === -1) {
+          this.searchOptions.push(option)
+        }
       },
-      showDropdownNoResults () {
-        return !Object.keys(this.dropdownOptions).length
+      handleSearch (query) {
+        if (query === null) {
+          this.searchOptions = null
+          return
+        }
+
+        query = query.toLowerCase()
+
+        if (this.asyncSearchCallback instanceof Function || this.asyncSearchUrl !== null) {
+          this.handleHideDropdownList()
+          let $vue = this
+          let promise = null
+          if (this.asyncSearchUrl !== null) {
+            promise = axios.get(this.asyncSearchUrl + (this.asyncSearchUrl.indexOf('?') === -1 ? '?' : '&') + 'query=' + query)
+          } else {
+            promise = this.asyncSearchCallback(query)
+          }
+
+          if (typeof promise.then === 'function' && typeof promise.catch === 'function') {
+            promise
+              .then((res) => {
+                $vue.searchOptions = $vue.convertOptionsToObjects(res.data)
+                this.handleShowDropdownList()
+              })
+              .catch((res) => {
+                console.log('Error response', res)
+                this.handleShowDropdownList()
+              })
+
+            return
+          }
+        }
+
+        let results = []
+        let options = Object.assign([], this.defaultSearchOptions)
+        for (let index = 0; index < options.length; index++) {
+          if (options[index][this.optionTitleName].toLowerCase().indexOf(query) !== -1) {
+            results.push(options[index])
+          }
+        }
+
+        this.searchOptions = results
+        this.handleShowDropdownList()
       },
-      showInput () {
-        return this.getProp('hasSearch')
+      convertOptionsToObjects (options) {
+        let results = []
+
+        if (typeof options === 'string') {
+          options = [options]
+        }
+
+        if (Array.isArray(options)) {
+          for (let index = 0; index < options.length; index++) {
+            if (options[index] instanceof Object) {
+              let obj = options[index]
+              if (typeof obj[this.optionTitleName] === 'undefined') {
+                continue
+              }
+              if (typeof obj[this.optionKeyName] === 'undefined') {
+                obj[this.optionKeyName] = obj[this.optionTitleName]
+              }
+              obj[this.optionKeyName] = Number.isInteger(obj[this.optionKeyName]) ? parseInt(obj[this.optionKeyName]) : obj[this.optionKeyName]
+              results.push(obj)
+            } else {
+              options[index] = Number.isInteger(options[index]) ? parseInt(options[index]) : options[index]
+              let searchInDefaultSearchOptions = false
+              if (this.defaultSearchOptions.length) {
+                for (let itemIndex = 0; itemIndex < this.defaultSearchOptions.length; itemIndex++) {
+                  if (this.defaultSearchOptions[itemIndex][this.optionKeyName] + '' === options[index] + '') {
+                    results.push(this.defaultSearchOptions[itemIndex])
+                    searchInDefaultSearchOptions = true
+                    break
+                  }
+                }
+              }
+              if (!searchInDefaultSearchOptions) {
+                results.push({
+                  [this.optionKeyName]: options[index],
+                  [this.optionTitleName]: options[index]
+                })
+              }
+            }
+          }
+        } else if (typeof options[this.optionKeyName] !== 'undefined' && typeof options[this.optionTitleName] !== 'undefined' && !this.isMulti) {
+          options[this.optionKeyName] = Number.isInteger(options[this.optionKeyName]) ? parseInt(options[this.optionKeyName]) : options[this.optionKeyName]
+          let object = {
+            [this.optionKeyName]: options[this.optionKeyName],
+            [this.optionTitleName]: options[this.optionTitleName]
+          }
+          if (typeof options[this.optionImageName] !== 'undefined') {
+            object[this.optionImageName] = options[this.optionImageName]
+          }
+          results.push(object)
+        } else {
+          for (let key in options) {
+            let id = Number.isInteger(key) ? parseInt(key) : key
+            results.push({
+              [this.optionKeyName]: id,
+              [this.optionTitleName]: options[key]
+            })
+          }
+        }
+
+        return results
       },
-      showDropdownHighlightTitle () {
-        return this.query.length && this.getProp('hasHighlights')
+      getChildrenByName (name) {
+        for (let index = 0; index < this.$children.length; index++) {
+          let child = this.$children[index]
+          if (child.$options._componentTag === name) {
+            return child
+          }
+        }
+
+        return null
+      },
+      handleKeyDown (event) {
+        let dropdown = this.getChildrenByName('list')
+        let search = this.getChildrenByName('search')
+
+        if (event.key === 'ArrowDown') {
+          event.preventDefault()
+          if (!this.showDropdownList) {
+            this.handleShowDropdownList()
+          } else {
+            dropdown.handlePressDown()
+          }
+        } else if (event.key === 'ArrowUp' && this.showDropdownList) {
+          event.preventDefault()
+          dropdown.handlePressUp()
+        } else if (event.key === 'Enter' && this.showDropdownList) {
+          dropdown.handleSelect(dropdown.$options.propsData.options[dropdown._data.hoverIndex], event)
+          if (!this.isMulti) {
+            dropdown._data.hoverIndex = null
+          }
+        } else if (event.key !== 'Tab' && this.showSearch) {
+          search.$refs.input.focus()
+        } else if (event.key === 'Tab') {
+          this.handleHideDropdownList()
+        }
       }
-    }
+    },
+    mounted () {
+      this.selectedOptions = this.convertOptionsToObjects(this.value)
+    },
+    
   }
 </script>
 
-<style type="text/css">
-    .list-group-item.individual-item {
-        border-radius: .25rem;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        -webkit-user-select: none;
-    }
-
-    .list-group-item.individual-item + .list-group-item.individual-item {
-        margin-top: 0.5rem;
-    }
-
-    .list-group-item img, .individual-item img {
-        max-width: 100px;
-        max-height: 50px;
-    }
-
-    .individual-item img {
-        border-top-left-radius: .25rem;
-        border-bottom-left-radius: .25rem;
-    }
-
-    .multiselect input {
+<style>
+    input:focus {
         outline: none;
-        font-size: 1rem;
-        line-height: 1.25;
-        color: #495057;
-        background-color: #fff;
-        background-image: none;
-        background-clip: padding-box;
-        transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-        width: calc(100% - 25px);
     }
 
-    .multiselect input::placeholder, .multiselect .stub {
-        color: rgb(135, 142, 149);
-    }
-
-    .multiselect.disabled input {
-        background-color: #e9ecef;
-    }
-
-    .multiselect [class^="icon-"]:hover {
-        opacity: 0.8;
-        cursor: pointer;
-    }
-
-    .multiselect.disabled [class^="icon-"]:hover {
-        opacity: 1;
-        cursor: default;
-    }
-
-    .multiselect.disabled {
-        opacity: 1;
-        cursor: default !important;
-        outline: none !important;
-        border: 1px solid rgba(0, 0, 0, .15);
-        background-color: #e9ecef;
-    }
-
-    .dropdown-list {
-        z-index: 2000;
-        max-height: 250px;
-        overflow-y: auto;
-        position: absolute;
-        box-shadow: 0 5px 10px rgba(0, 0, 0, .3);
-        border-radius: .25rem;
+    .multiselect {
         -moz-user-select: none;
         -ms-user-select: none;
         -webkit-user-select: none;
-    }
-
-    .list-group-item.bg-light {
-        cursor: pointer;
+        min-height: 36px;
     }
 </style>


### PR DESCRIPTION
I have added reactivity for the **defaultSearchOptions** property, now when the parent component pass a computed property throught the `props` options, the `defaultSearchOptions` will be able to update automatically. 

In my case of use, i used this to show objects returned from an `asyncSearchCallback` callback function, this function does a request for my backend and put the result in a computed property wich is passed as `:all-values` parameter, before i do this, the option list in my multiselect did not update, now it updates instantly.